### PR TITLE
fixed controller req.params.id to req.params.inventoryId

### DIFF
--- a/controllers/inventoryController.js
+++ b/controllers/inventoryController.js
@@ -39,14 +39,14 @@ const addInventoryItem = (req, res) => {
 // get single inventory detail
 const singleInventoryItem = (req, res) => {
     const inventoryData = JSON.parse(fs.readFileSync("./data/inventories.json"));
-    let selectedInventory = inventoryData.find(inventories => inventories.id === req.params.id)
+    let selectedInventory = inventoryData.find(inventories => inventories.id === req.params.inventoryId)
     res.status(200).json(selectedInventory)
 }
 
 // delete /inventory id => delete inventory items from data files
 const deleteInventoryItem = (req, res) => {
     // get inventory id from url
-    const inventoryId = req.params.id;
+    const inventoryId = req.params.inventoryId;
     // remove specified inventory items using inventory id
     const inventoryData = JSON.parse(fs.readFileSync("./data/inventories.json"));
     // write the updated inventory data back to the json files


### PR DESCRIPTION
I found a bug in backend, for this route, at some point /:id was changed to /:inventoryId 
and some of the controllers were still using` req.params.id`, so i changed them to `req.params.inventoryId`